### PR TITLE
Update install script w/subproc

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -63,6 +63,6 @@ installed. Start up CASA as normal, and type::
 
 Now, quit CASA and re-open it, then type the following to install ``spectral-cube``::
 
-    CASA <1>: import pip
+    CASA <1>: import subprocess, sys
 
-    CASA <2>: pip.main(['install', 'spectral-cube', '--user'])
+    CASA <2>: subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'spectral-cube'])


### PR DESCRIPTION
Our install instructions use the deprecated `pip.main` and shouldn't.

https://docs.astropy.org/en/latest/install.html#installing-astropy-into-casa is the "right way" to hackinstall stuff into old casa.